### PR TITLE
Add missing braces in CORS.md

### DIFF
--- a/service-settings/CORS.md
+++ b/service-settings/CORS.md
@@ -52,6 +52,7 @@ CORS configuration lives in the root of the file, as it's a service component. A
       "debug": false
     }
   }
+}
 ```
 The configuration options of this component are as follows:
 
@@ -145,5 +146,6 @@ To support `OPTIONS` in your endpoints, you only need to add the [flag `auto_opt
       "@comment": "...CORS configuration inside this block..."
     }
   }
+}
 ```
 {{< schema data="router.json" filter="auto_options" >}}


### PR DESCRIPTION
There were two missing end braces in the CORS documentation. It can be a bit confusing if one copies and pastes the code, and it has errors.