### PR TITLE
Doc:Community edition 2.9.4 --  context missing from instructions

### DIFF
--- a/developer/hot-reload.md
+++ b/developer/hot-reload.md
@@ -24,7 +24,7 @@ To use the `:watch` image on the Open Source edition, [clone the `krakend-watch`
 ```bash
 git clone https://github.com/krakend/krakend-watch.git
 cd krakend-watch
-docker build -t {{< product image >}}:watch
+docker build -t {{< product image >}}:watch .
 ```
 If you want to pin a specific KrakenD version, replace the `:latest` string on the `Dockerfile` with your desired version before building.
 


### PR DESCRIPTION
I think most people trying to build the Docker image will know what to do, but here is a PR just in case :)